### PR TITLE
Remove dependency to 3rd party icons, embedding them

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,18 +1,293 @@
 {
-  "name": "lugh-frontend",
+  "name": "metaphrase-frontend",
   "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "@babel/core": {
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
+      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.12.15",
+        "@babel/helper-module-transforms": "^7.12.13",
+        "@babel/helpers": "^7.12.13",
+        "@babel/parser": "^7.12.16",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.12.15",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
+      "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.16.tgz",
+      "integrity": "sha512-KbSEj8l9zYkMVHpQqM3wJNxS1d9h3U9vm/uE5tpjMbaj3lTp+0noe3KPsV5dSD9jxKnf9jO9Ip9FX5PKNZCKow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-member-expression-to-functions": "^7.12.16",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
+      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.12.13",
+        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
+      "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+      "dev": true
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
+      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.12.13",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
+    "@babel/helpers": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
+      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@babel/parser": {
       "version": "7.12.15",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
       "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA=="
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
+      "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
+      "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.16.tgz",
+      "integrity": "sha512-88hep+B6dtDOiEqtRzwHp2TYO+CN8nbAV3eh5OpBGPsedug9J6y1JwLKzXRIGGQZDC8NlpxpQMIIxcfIW96Wgw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.16",
+        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/plugin-syntax-typescript": "^7.12.13"
+      }
+    },
+    "@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
+      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.12.13",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
     },
     "@babel/types": {
       "version": "7.12.13",
@@ -24,23 +299,47 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@iconify/json": {
-      "version": "1.1.300",
-      "resolved": "https://registry.npmjs.org/@iconify/json/-/json-1.1.300.tgz",
-      "integrity": "sha512-Zg1xQHWoKkK4dZJzSOXMd4Jqk8G+iTJg1gOZEMjv4dxPT6idORuIfYkcdGhLD6Ky8d7BkoArQJzDGvQavpbz/w==",
-      "dev": true
-    },
-    "@iconify/json-tools": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@iconify/json-tools/-/json-tools-1.0.10.tgz",
-      "integrity": "sha512-LFelJDOLZ6JHlmlAkgrvmcu4hpNPB91KYcr4f60D/exzU1eNOb4/KCVHIydGHIQFaOacIOD+Xy+B7P1z812cZg==",
-      "dev": true
-    },
     "@vitejs/plugin-vue": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.1.4.tgz",
       "integrity": "sha512-cUDILd++9jdhdjpuhgJofQqOabOKe+kTWTE2HQY2PBHEUO2fgwTurLE0cJg9UcIo1x4lHfsp+59S9TBCHgTZkw==",
       "dev": true
+    },
+    "@vitejs/plugin-vue-jsx": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-1.1.0.tgz",
+      "integrity": "sha512-7fpB9rdhWZ7DSdcK/w2sEuSaeOiSyhwu/2ojwl8qz1pshWEPQj9F2g9TaZtEBz298nOKBM0hUOCcKKRUO8Ga8A==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.10",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-transform-typescript": "^7.12.1",
+        "@vue/babel-plugin-jsx": "^1.0.1",
+        "hash-sum": "^2.0.0"
+      }
+    },
+    "@vue/babel-helper-vue-transform-on": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.0.2.tgz",
+      "integrity": "sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==",
+      "dev": true
+    },
+    "@vue/babel-plugin-jsx": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.0.3.tgz",
+      "integrity": "sha512-+52ZQFmrM0yh61dQlgwQlfHZXmYbswbQEL25SOSt9QkjegAdfIGu87oELw0l8H6cuJYazZCiNjPR9eU++ZIbxg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "@vue/babel-helper-vue-transform-on": "^1.0.2",
+        "camelcase": "^6.0.0",
+        "html-tags": "^3.1.0",
+        "svg-tags": "^1.0.0"
+      }
     },
     "@vue/compiler-core": {
       "version": "3.0.5",
@@ -150,6 +449,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
+    "camelcase": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -202,6 +507,15 @@
         "bluebird": "^3.7.2"
       }
     },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -212,6 +526,15 @@
       "version": "2.6.14",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
       "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -258,6 +581,18 @@
         "loader-utils": "^1.1.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -277,6 +612,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "dev": true
+    },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true
     },
     "icss-replace-symbols": {
@@ -308,6 +649,18 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json5": {
       "version": "1.0.1",
@@ -371,6 +724,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "nanoid": {
@@ -491,6 +850,18 @@
         "fsevents": "~2.3.1"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -516,6 +887,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -558,15 +935,6 @@
             "source-map": "^0.6.1"
           }
         }
-      }
-    },
-    "vite-plugin-icons": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-icons/-/vite-plugin-icons-0.2.1.tgz",
-      "integrity": "sha512-ZIJ8G2AHwEDt4oDST46E6Uy7W2EtVyoe1hzmJMkutbq3esUkcYVoYydT6Y12lhq1ppnVnShkbc0XzfKqolfCSg==",
-      "dev": true,
-      "requires": {
-        "@iconify/json-tools": "^1.0.10"
       }
     },
     "vue": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -18,10 +18,9 @@
     "lodash": "^4.17.20"
   },
   "devDependencies": {
-    "@iconify/json": "^1.1.300",
     "@vitejs/plugin-vue": "^1.1.4",
+    "@vitejs/plugin-vue-jsx": "^1.1.0",
     "@vue/compiler-sfc": "^3.0.5",
-    "vite": "^2.0.0-beta.65",
-    "vite-plugin-icons": "^0.2.1"
+    "vite": "^2.0.0-beta.65"
   }
 }

--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -282,6 +282,8 @@ body {
   margin-left: 6px;
   margin-top: 8px;
   color: grey;
+  width: 16px;
+  height: 16px;
 }
 
 .icon-prepend + input {

--- a/src/frontend/src/assets/Icons.jsx
+++ b/src/frontend/src/assets/Icons.jsx
@@ -1,0 +1,54 @@
+import { defineComponent } from "vue";
+
+function createIcon(name) {
+  return {
+    name,
+    render() {
+      return (
+        <svg width="24px" height="24px" viewBox="0 0 24 24">
+          {/* Those defaut widths and heights, as any other attributes, can be overridden on call site. */}
+          <path d={ICONS_PATHS[name]} fill="currentColor" />
+        </svg>
+      );
+    },
+  };
+}
+
+// All the icons "path" definitions, in alphabetical order.
+// Prettier formatting is ignored on this object to ensure each path
+// is defined on one and only line for readability purposes.
+// prettier-ignore
+const ICONS_PATHS = {
+  IconCheck: "M21 7L9 19l-5.5-5.5l1.41-1.41L9 16.17L19.59 5.59L21 7z",
+  IconClose: "M20 6.91L17.09 4L12 9.09L6.91 4L4 6.91L9.09 12L4 17.09L6.91 20L12 14.91L17.09 20L20 17.09L14.91 12L20 6.91z",
+  IconPlus: "M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z",
+  IconChevronRight: "M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6l-1.41-1.42z",
+  IconFile: "M13 9V3.5L18.5 9M6 2c-1.11 0-2 .89-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6z",
+  IconFolder: "M10 4H4c-1.11 0-2 .89-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2z",
+  IconKey: "M7 14a2 2 0 0 1-2-2a2 2 0 0 1 2-2a2 2 0 0 1 2 2a2 2 0 0 1-2 2m5.65-4A5.99 5.99 0 0 0 7 6a6 6 0 0 0-6 6a6 6 0 0 0 6 6a5.99 5.99 0 0 0 5.65-4H17v4h4v-4h2v-4H12.65z",
+  IconLock: "M12 17a2 2 0 0 0 2-2a2 2 0 0 0-2-2a2 2 0 0 0-2 2a2 2 0 0 0 2 2m6-9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2h1V6a5 5 0 0 1 5-5a5 5 0 0 1 5 5v2h1m-6-5a3 3 0 0 0-3 3v2h6V6a3 3 0 0 0-3-3z",
+  IconLogin: "M19 3H5c-1.11 0-2 .89-2 2v4h2V5h14v14H5v-4H3v4a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2m-8.92 12.58L11.5 17l5-5l-5-5l-1.42 1.41L12.67 11H3v2h9.67l-2.59 2.58z",
+  IconLogout: "M14.08 15.59L16.67 13H7v-2h9.67l-2.59-2.59L15.5 7l5 5l-5 5l-1.42-1.41M19 3a2 2 0 0 1 2 2v4.67l-2-2V5H5v14h14v-2.67l2-2V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5c0-1.11.89-2 2-2h14z",
+  IconSearch: "M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5l-1.5 1.5l-5-5v-.79l-.27-.27A6.516 6.516 0 0 1 9.5 16A6.5 6.5 0 0 1 3 9.5A6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14S14 12 14 9.5S12 5 9.5 5z",
+  IconTrash: "M9 3v1H4v2h1v13a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6h1V4h-5V3H9m0 5h2v9H9V8m4 0h2v9h-2V8z",
+  IconUser: "M12 4a4 4 0 0 1 4 4a4 4 0 0 1-4 4a4 4 0 0 1-4-4a4 4 0 0 1 4-4m0 10c4.42 0 8 1.79 8 4v2H4v-2c0-2.21 3.58-4 8-4z",
+  IconWarning: "M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2L1 21z",
+}
+
+// Exported icons, in alphabetical order.
+// For Vite to do its exporting/translating job correctly, lines have to
+// contains the `defineComponent`; the `createIcon` is a way to shorten it.
+export const IconCheck = defineComponent(createIcon("IconCheck"));
+export const IconChevronRight = defineComponent(createIcon("IconChevronRight"));
+export const IconClose = defineComponent(createIcon("IconClose"));
+export const IconFile = defineComponent(createIcon("IconFile"));
+export const IconFolder = defineComponent(createIcon("IconFolder"));
+export const IconKey = defineComponent(createIcon("IconKey"));
+export const IconLock = defineComponent(createIcon("IconLock"));
+export const IconLogin = defineComponent(createIcon("IconLogin"));
+export const IconLogout = defineComponent(createIcon("IconLogout"));
+export const IconPlus = defineComponent(createIcon("IconPlus"));
+export const IconSearch = defineComponent(createIcon("IconSearch"));
+export const IconTrash = defineComponent(createIcon("IconTrash"));
+export const IconUser = defineComponent(createIcon("IconUser"));
+export const IconWarning = defineComponent(createIcon("IconWarning"));

--- a/src/frontend/src/components/CollectionToolbar.vue
+++ b/src/frontend/src/components/CollectionToolbar.vue
@@ -1,44 +1,48 @@
 <template>
   <div class="collection-toolbar">
-    <button @click="showAddNewKey">
-      <IconPlus /> New key
-    </button>
+    <button @click="showAddNewKey"><IconPlus /> New key</button>
   </div>
 </template>
 
 <script>
-  import IconPlus from '/@vite-icons/mdi/plus.vue'
+import { IconPlus } from "../assets/Icons.jsx";
 
-  export default {
-    name: 'collection-toolbar',
+export default {
+  name: "collection-toolbar",
 
-    components: {
-      IconPlus
+  components: {
+    IconPlus,
+  },
+
+  methods: {
+    showAddNewKey() {
+      this.$emit("showAddNewKey");
     },
-
-    methods: {
-      showAddNewKey() {
-        this.$emit('showAddNewKey');
-      }
-    }
-  };
+  },
+};
 </script>
 
 <style>
-  .collection-toolbar {
-    display: flex;
-    background-color: lightgrey;
-    border-bottom: 1px solid grey;
-    height: 39px;
-    align-items: center;
-    padding-left: 6px;
-  }
+.collection-toolbar {
+  display: flex;
+  background-color: lightgrey;
+  border-bottom: 1px solid grey;
+  height: 39px;
+  align-items: center;
+  padding-left: 6px;
+}
 
-  .collection-toolbar button {
-    border: 1px solid grey;
-    border-radius: 3px;
-    font-family: inherit;
-    font-size: 14px;
-    padding: 4px;
-  }
+.collection-toolbar button {
+  border: 1px solid grey;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 4px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.collection-toolbar svg {
+  margin-right: 5px;
+}
 </style>

--- a/src/frontend/src/components/LoginPrompt.vue
+++ b/src/frontend/src/components/LoginPrompt.vue
@@ -14,17 +14,19 @@
       </label>
       <p class="error" v-if="loginError"><IconWarning /> {{ loginError }}</p>
       <p class="controls">
-        <button><IconLoginVariant /> Login</button>
+        <button><IconLogin /> Login</button>
       </p>
     </form>
   </div>
 </template>
 
 <script>
-import IconUser from "/@vite-icons/mdi/user.vue";
-import IconLock from "/@vite-icons/mdi/lock.vue";
-import IconWarning from "/@vite-icons/mdi/warning.vue";
-import IconLoginVariant from "/@vite-icons/mdi/login-variant.vue";
+import {
+  IconUser,
+  IconLock,
+  IconWarning,
+  IconLogin,
+} from "../assets/Icons.jsx";
 
 export default {
   name: "login-prompt",
@@ -33,7 +35,7 @@ export default {
     IconUser,
     IconLock,
     IconWarning,
-    IconLoginVariant,
+    IconLogin,
   },
 
   data() {
@@ -113,9 +115,11 @@ export default {
 
 .login-dialog input + svg {
   position: absolute;
-  left: 25px;
-  margin-top: -1.65em;
+  left: 28px;
+  margin-top: -24px;
   color: #aaaaaa;
+  width: 16px;
+  height: 16px;
 }
 
 .login-dialog input:active + svg,
@@ -148,6 +152,8 @@ export default {
   background-color: #eeeeee;
   border: 1px solid #aaaaaa;
   outline: none;
+  display: inline-flex;
+  align-items: center;
 }
 
 .login-dialog .controls button::-moz-focus-inner {
@@ -169,6 +175,10 @@ export default {
   box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
+.login-dialog .controls button svg {
+  margin-right: 5px;
+}
+
 .login-dialog .error {
   border: 1px solid darkred;
   color: darkred;
@@ -176,5 +186,9 @@ export default {
   background-color: #ffc8ca;
   margin: 15px -20px 5px;
   padding: 5px 20px;
+}
+
+.login-dialog .error svg {
+  vertical-align: -33%;
 }
 </style>

--- a/src/frontend/src/components/NavigationBar.vue
+++ b/src/frontend/src/components/NavigationBar.vue
@@ -29,8 +29,7 @@
 </template>
 
 <script>
-import IconSearch from "/@vite-icons/mdi/search.vue";
-import IconChevronRight from "/@vite-icons/mdi/chevron-right.vue";
+import { IconChevronRight, IconSearch } from "../assets/Icons.jsx";
 
 import NavigationKey from "./NavigationKey.vue";
 import _ from "lodash";
@@ -136,6 +135,8 @@ export default {
   top: 50%;
   transform: translateY(-50%) !important;
   color: grey;
+  width: 16px;
+  height: 16px;
 }
 
 .search-bar input {

--- a/src/frontend/src/components/NavigationKey.vue
+++ b/src/frontend/src/components/NavigationKey.vue
@@ -10,9 +10,7 @@
 </template>
 
 <script>
-import IconFile from "/@vite-icons/mdi/file.vue";
-import IconFolder from "/@vite-icons/mdi/folder.vue";
-import IconChevronRight from "/@vite-icons/mdi/chevron-right.vue";
+import { IconFile, IconFolder, IconChevronRight } from "../assets/Icons.jsx";
 import _ from "lodash";
 
 export default {

--- a/src/frontend/src/components/Toolbar.vue
+++ b/src/frontend/src/components/Toolbar.vue
@@ -1,18 +1,18 @@
 <template>
   <div id="toolbar">
     <h1>Metaphrase</h1>
-    <button @click="logout"><IconLogoutVariant /> Logout</button>
+    <button @click="logout"><IconLogout /> Logout</button>
   </div>
 </template>
 
 <script>
-import IconLogoutVariant from "/@vite-icons/mdi/logout-variant.vue";
+import { IconLogout } from "../assets/Icons.jsx";
 
 export default {
   name: "toolbar",
 
   components: {
-    IconLogoutVariant,
+    IconLogout,
   },
 
   methods: {
@@ -37,6 +37,8 @@ export default {
 }
 
 #toolbar button {
+  display: inline-flex;
+  padding: 3px 8px;
   border: 1px solid black;
   background-color: rgba(255, 255, 255, 0.2);
   color: white;
@@ -61,5 +63,9 @@ export default {
 
 #toolbar button::-moz-focus-inner {
   border: 0;
+}
+
+#toolbar button svg {
+  margin-right: 5px;
 }
 </style>

--- a/src/frontend/src/components/TranslationKey.vue
+++ b/src/frontend/src/components/TranslationKey.vue
@@ -29,10 +29,12 @@
 </template>
 
 <script>
-import IconFile from "/@vite-icons/mdi/file.vue";
-import IconFolder from "/@vite-icons/mdi/folder.vue";
-import IconChevronRight from "/@vite-icons/mdi/chevron-right.vue";
-import IconTrash from "/@vite-icons/mdi/trash.vue";
+import {
+  IconFile,
+  IconFolder,
+  IconChevronRight,
+  IconTrash,
+} from "../assets/Icons.jsx";
 
 export default {
   name: "translation-key",

--- a/src/frontend/src/components/TranslationLocale.vue
+++ b/src/frontend/src/components/TranslationLocale.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import IconCheck from "/@vite-icons/mdi/check.vue";
+import { IconCheck } from "../assets/Icons.jsx";
 import Flag from "./Flag.vue";
 
 export default {

--- a/src/frontend/src/components/modals/AddNewKeyModal.vue
+++ b/src/frontend/src/components/modals/AddNewKeyModal.vue
@@ -29,9 +29,7 @@
 </template>
 
 <script>
-import IconClose from "/@vite-icons/mdi/close.vue";
-import IconPlus from "/@vite-icons/mdi/plus.vue";
-import IconKey from "/@vite-icons/mdi/key.vue";
+import { IconClose, IconPlus, IconKey } from "../../assets/Icons.jsx";
 
 export default {
   name: "add-new-key-modal",

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -1,12 +1,12 @@
 import vue from "@vitejs/plugin-vue";
-import Icons from "vite-plugin-icons";
+import vueJsx from "@vitejs/plugin-vue-jsx";
 
 /**
  * https://vitejs.dev/config/
  * @type {import('vite').UserConfig}
  */
 export default {
-  plugins: [vue(), Icons()],
+  plugins: [vue(), vueJsx()],
   server: {
     port: 3100,
     proxy: {


### PR DESCRIPTION
While writing #55 and testing setup instructions, I spot some problems with the `vite-plugin-icons` on first setup; it was worrying and told me that we didn't need such a shim around icons where we'll use maybe 60 at most in the final product. I simply created a `Icons.jsx` (yep, `jsx`, to allow us a very concise file) that contains all the icons we already use and updated the files that used them in the process.